### PR TITLE
Add v2 to module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ldez/go-auroradns
+module github.com/ldez/go-auroradns/v2
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect


### PR DESCRIPTION
I was unaware that this library was at `v2` already, so the module path should reflect that. Sorry about this, I'm still quite new to Go modules...